### PR TITLE
tekton: set timeout to 4h

### DIFF
--- a/.tekton/vllm-pull-request.yaml
+++ b/.tekton/vllm-pull-request.yaml
@@ -17,6 +17,8 @@ metadata:
   name: vllm-on-pull-request
   namespace: rhoai-tenant
 spec:
+  timeouts:
+    pipeline: 4h
   params:
   - name: git-url
     value: '{{source_url}}'

--- a/.tekton/vllm-push.yaml
+++ b/.tekton/vllm-push.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: rhoai-tenant
 spec:
   timeouts:
-    pipeline: 8h
+    pipeline: 4h
   params:
   - name: git-url
     value: '{{source_url}}'


### PR DESCRIPTION
pull-request builds are currently failing due to the default 60m timeout