### PR TITLE
Dockerfile.ubi: add env vars to prevent numba/outlines errors

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -181,6 +181,9 @@ ENV HF_HUB_OFFLINE=1 \
     VLLM_ALLOW_LONG_MAX_MODEL_LEN=1 \
     VLLM_USAGE_SOURCE=production-docker-image \
     VLLM_WORKER_MULTIPROC_METHOD=fork \
+    OUTLINES_CACHE_DIR=/tmp/outlines \
+    NUMBA_CACHE_DIR=/tmp/numba \
+    TRITON_CACHE_DIR=/tmp/triton \
     VLLM_NO_USAGE_STATS=1
 
 # setup non-root user for OpenShift


### PR DESCRIPTION
See explanation here: [opendatahub-io/vllm#211](https://github.com/opendatahub-io/vllm/pull/211)