### PR TITLE
Dockerfile.rocm.ubi: set cmake<4 constraint

### DIFF
--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -129,7 +129,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     cd flash-attention && \
     git checkout ${FA_BRANCH} && \
     git submodule update --init && \
-    uv pip install cmake ninja packaging && \
+    uv pip install "cmake<4" ninja packaging && \
     env \
         GPU_ARCHS="${FA_GFX_ARCHS}" \
         python3 setup.py bdist_wheel --dist-dir=/install
@@ -154,7 +154,7 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install -v -U \
-        ninja setuptools-scm>=8 "cmake>=3.26" packaging && \
+        ninja setuptools-scm>=8 "cmake>=3.26,<4" packaging && \
     env CFLAGS="-march=haswell" \
         CXXFLAGS="$CFLAGS $CXXFLAGS" \
         CMAKE_BUILD_TYPE=Release \


### PR DESCRIPTION
`cmake==4.0` came out ~12h ago, causing the vllm ROCm build to break.

This PR pins `cmake<4` for both `vllm` and `flash-attention` builds (although flash-attention builds fine with `cmake==4.0`)
