### PR TITLE
Dockerfile.ubi: update flashinfer, add blackwell

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -151,7 +151,7 @@ RUN microdnf install -y --nodocs gcc \
 RUN --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install "$(echo dist/*.whl)[audio,video,tensorizer]" --verbose \
-    "https://github.com/flashinfer-ai/flashinfer/releases/download/v0.2.5/flashinfer_python-0.2.5+cu128torch2.7-cp38-abi3-linux_aarch64.whl"
+    "https://storage.googleapis.com/neuralmagic-public-pypi/dist/flashinfer_python-0.2.5-cp38-abi3-linux_x86_64.whl"
 
 # Install libsodium for Tensorizer encryption
 RUN --mount=type=bind,from=libsodium-builder,src=/usr/src/libsodium,target=/usr/src/libsodium \

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -4,7 +4,7 @@ ARG PYTHON_VERSION=3.12
 ARG VLLM_VERSION
 ARG VLLM_TGIS_ADAPTER_VERSION="0.7.1"
 ARG LIBSODIUM_VERSION=1.0.20
-ARG TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6 8.9 9.0+PTX"
+ARG TORCH_CUDA_ARCH_LIST="7.0 7.5 8.0 8.6 8.9 9.0 10.0 12.0+PTX"
 ARG vllm_fa_cmake_gpu_arches='80-real;90-real'
 
 ## Base Layer ##################################################################


### PR DESCRIPTION
- Dockerfile.ubi: update flashinfer to 0.2.5 (cu128)
- Dockerfile.ubi: TORCH_CUDA_ARCH_LIST: add 10.0 and 12.0+PTX (blackwell)

https://issues.redhat.com/browse/RHOAIENG-26191