### PR TITLE
Dockerfile.ubi: set uv torch index url to cu128

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -150,8 +150,10 @@ RUN microdnf install -y --nodocs gcc \
 # install vllm wheel first, so that torch etc will be installed
 RUN --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist \
     --mount=type=cache,target=/root/.cache/uv \
-    uv pip install "$(echo dist/*.whl)[audio,video,tensorizer]" --verbose \
-    "https://storage.googleapis.com/neuralmagic-public-pypi/dist/flashinfer_python-0.2.5-cp38-abi3-linux_x86_64.whl"
+    uv pip install \
+        --extra-index-url="https://download.pytorch.org/whl/cu128" --index-strategy='unsafe-best-match' \
+        "$(echo dist/*.whl)[audio,video,tensorizer]" --verbose \
+        "https://storage.googleapis.com/neuralmagic-public-pypi/dist/flashinfer_python-0.2.5-cp38-abi3-linux_x86_64.whl"
 
 # Install libsodium for Tensorizer encryption
 RUN --mount=type=bind,from=libsodium-builder,src=/usr/src/libsodium,target=/usr/src/libsodium \
@@ -199,7 +201,10 @@ USER root
 ARG VLLM_TGIS_ADAPTER_VERSION
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,from=build,src=/workspace/dist,target=/workspace/dist \
-    HOME=/root uv pip install "$(echo /workspace/dist/*.whl)[audio,video,tensorizer]" vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
+    HOME=/root uv pip install \
+        --extra-index-url="https://download.pytorch.org/whl/cu128" --index-strategy='unsafe-best-match' \
+        "$(echo /workspace/dist/*.whl)[audio,video,tensorizer]" \
+        vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \


### PR DESCRIPTION
Bumping cuda to 12.8 requires to install `torch==2.7+cu128`, which has to be sourced from the proper index url


https://issues.redhat.com/browse/RHOAIENG-26191