### PR TITLE
fix bad merge with midstream-v0.9.0.1.0

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -15,7 +15,6 @@ from ray.experimental.tqdm_ray import tqdm
 
 from vllm.model_executor.layers.fused_moe.fused_moe import *
 from vllm.platforms import current_platform
-from vllm.transformers_utils.config import get_config
 from vllm.triton_utils import triton
 from vllm.utils import FlexibleArgumentParser
 

--- a/benchmarks/kernels/deepgemm/benchmark_fp8_block_dense_gemm.py
+++ b/benchmarks/kernels/deepgemm/benchmark_fp8_block_dense_gemm.py
@@ -11,9 +11,7 @@ from deep_gemm import calc_diff, ceil_div, get_col_major_tma_aligned_tensor
 # Import vLLM functions
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-    per_token_group_quant_fp8,
-    w8a8_block_fp8_matmul,
-)
+    per_token_group_quant_fp8, w8a8_block_fp8_matmul)
 from vllm.triton_utils import triton
 
 

--- a/vllm/triton_utils/importing.py
+++ b/vllm/triton_utils/importing.py
@@ -16,32 +16,34 @@ if not HAS_TRITON:
     logger.info("Triton not installed or not compatible; certain GPU-related"
                 " functions will not be available.")
 
-    class TritonPlaceholder(types.ModuleType):
 
-        def __init__(self):
-            super().__init__("triton")
-            self.jit = self._dummy_decorator("jit")
-            self.autotune = self._dummy_decorator("autotune")
-            self.heuristics = self._dummy_decorator("heuristics")
-            self.language = TritonLanguagePlaceholder()
-            logger.warning_once(
-                "Triton is not installed. Using dummy decorators. "
-                "Install it via `pip install triton` to enable kernel"
-                "compilation.")
+class TritonPlaceholder(types.ModuleType):
 
-        def _dummy_decorator(self, name):
+    def __init__(self):
+        super().__init__("triton")
+        self.jit = self._dummy_decorator("jit")
+        self.autotune = self._dummy_decorator("autotune")
+        self.heuristics = self._dummy_decorator("heuristics")
+        self.language = TritonLanguagePlaceholder()
+        logger.warning_once(
+            "Triton is not installed. Using dummy decorators. "
+            "Install it via `pip install triton` to enable kernel"
+            " compilation.")
 
-            def decorator(func=None, **kwargs):
-                if func is None:
-                    return lambda f: f
-                return func
+    def _dummy_decorator(self, name):
 
-            return decorator
+        def decorator(*args, **kwargs):
+            if args and callable(args[0]):
+                return args[0]
+            return lambda f: f
 
-    class TritonLanguagePlaceholder(types.ModuleType):
+        return decorator
 
-        def __init__(self):
-            super().__init__("triton.language")
-            self.constexpr = None
-            self.dtype = None
-            self.int64 = None
+
+class TritonLanguagePlaceholder(types.ModuleType):
+
+    def __init__(self):
+        super().__init__("triton.language")
+        self.constexpr = None
+        self.dtype = None
+        self.int64 = None


### PR DESCRIPTION

a bad merge with https://github.com/neuralmagic/nm-vllm-ent/releases/tag/midstream-cuda-v0.9.0.1.0
caused `f9bc5a069` (https://github.com/vllm-project/vllm/pull/17446) to be missing from the rhoai-2.21 branch, causing vLLM to fail to start up.

fixes https://issues.redhat.com/browse/RHOAIENG-27290

