### PR TITLE
patch: upgrade vllm tgis adapter to 0.9.0.post1

### DIFF
--- a/Dockerfile.konflux.cuda
+++ b/Dockerfile.konflux.cuda
@@ -1,8 +1,24 @@
 ## Global Args #################################################################
 ARG RHAIIS_VERSION=3.2.2
+ARG VLLM_TGIS_ADAPTER_VERSION="0.8.1"
 
 ## Base Layer ##################################################################
 FROM registry.redhat.io/rhaiis/vllm-cuda-rhel9:${RHAIIS_VERSION} as vllm-grpc-adapter
+
+# Install uv and setup cache directory with correct permissions
+USER root
+RUN pip install uv && \
+    mkdir -p /opt/app-root/.cache/uv && \
+    chown -R 2000:2000 /opt/app-root/.cache && \
+    chmod -R 775 /opt/app-root/.cache
+
+## Install vLLM-TGIS-Adapter ####################################################
+ARG VLLM_TGIS_ADAPTER_VERSION
+USER 2000
+RUN --mount=type=cache,target=/opt/app-root/.cache/uv,uid=2000,gid=2000 \
+    HOME=/opt/app-root uv pip install \
+        --extra-index-url="https://download.pytorch.org/whl/cu128" \
+        vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \
@@ -12,7 +28,7 @@ ENV GRPC_PORT=8033 \
     # see: https://github.com/vllm-project/vllm/pull/6485
     DISABLE_LOGPROBS_DURING_SPEC_DECODING=false
 
-USER 2000
+
 ENTRYPOINT ["python3", "-m", "vllm_tgis_adapter", "--uvicorn-log-level=warning"]
 
 LABEL name="rhoai/odh-vllm-cuda-rhel9" \

--- a/Dockerfile.konflux.cuda
+++ b/Dockerfile.konflux.cuda
@@ -5,7 +5,7 @@ ARG RHAIIS_VERSION=3.2.2
 ## Base Layer ##################################################################
 FROM registry.redhat.io/rhaiis/vllm-cuda-rhel9:${RHAIIS_VERSION} as vllm-grpc-adapter
 
-ARG VLLM_TGIS_ADAPTER_VERSION="0.9.0"
+ARG VLLM_TGIS_ADAPTER_VERSION="0.9.0.post1"
 USER root
 
 ## Install vLLM-TGIS-Adapter ####################################################

--- a/Dockerfile.konflux.cuda
+++ b/Dockerfile.konflux.cuda
@@ -11,7 +11,7 @@ USER root
 ## Install vLLM-TGIS-Adapter ####################################################
 RUN pip install --no-cache --no-deps vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
 
-USER 2000
+USER 1001
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \

--- a/Dockerfile.konflux.cuda
+++ b/Dockerfile.konflux.cuda
@@ -30,4 +30,5 @@ LABEL name="rhoai/odh-vllm-cuda-rhel9" \
       io.k8s.description="GPU-accelerated vLLM build using NVIDIA CUDA for high-performance inference." \
       description="GPU-accelerated vLLM build using NVIDIA CUDA for high-performance inference." \
       summary="GPU-accelerated vLLM build using NVIDIA CUDA for high-performance inference." \
+      
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"

--- a/Dockerfile.konflux.cuda
+++ b/Dockerfile.konflux.cuda
@@ -30,5 +30,5 @@ LABEL name="rhoai/odh-vllm-cuda-rhel9" \
       io.k8s.description="GPU-accelerated vLLM build using NVIDIA CUDA for high-performance inference." \
       description="GPU-accelerated vLLM build using NVIDIA CUDA for high-performance inference." \
       summary="GPU-accelerated vLLM build using NVIDIA CUDA for high-performance inference." \
-      
       com.redhat.license_terms="https://www.redhat.com/licenses/Red_Hat_Standard_EULA_20191108.pdf"
+      

--- a/Dockerfile.konflux.cuda
+++ b/Dockerfile.konflux.cuda
@@ -11,6 +11,8 @@ USER root
 ## Install vLLM-TGIS-Adapter ####################################################
 RUN pip install --no-cache --no-deps vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
 
+USER 2000
+
 ENV GRPC_PORT=8033 \
     PORT=8000 \
     # As an optimization, vLLM disables logprobs when using spec decoding by

--- a/Dockerfile.konflux.cuda
+++ b/Dockerfile.konflux.cuda
@@ -1,24 +1,15 @@
 ## Global Args #################################################################
 ARG RHAIIS_VERSION=3.2.2
-ARG VLLM_TGIS_ADAPTER_VERSION="0.8.1"
+
 
 ## Base Layer ##################################################################
 FROM registry.redhat.io/rhaiis/vllm-cuda-rhel9:${RHAIIS_VERSION} as vllm-grpc-adapter
 
-# Install uv and setup cache directory with correct permissions
+ARG VLLM_TGIS_ADAPTER_VERSION="0.9.0"
 USER root
-RUN pip install uv && \
-    mkdir -p /opt/app-root/.cache/uv && \
-    chown -R 2000:2000 /opt/app-root/.cache && \
-    chmod -R 775 /opt/app-root/.cache
 
 ## Install vLLM-TGIS-Adapter ####################################################
-ARG VLLM_TGIS_ADAPTER_VERSION
-USER 2000
-RUN --mount=type=cache,target=/opt/app-root/.cache/uv,uid=2000,gid=2000 \
-    HOME=/opt/app-root uv pip install \
-        --extra-index-url="https://download.pytorch.org/whl/cu128" \
-        vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
+RUN pip install --no-cache --no-deps vllm-tgis-adapter==${VLLM_TGIS_ADAPTER_VERSION}
 
 ENV GRPC_PORT=8033 \
     PORT=8000 \


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHOAIENG-35041
Upgrade vllm-tgis-adapter to 0.9.0 to fix
``ModuleNotFoundError: No module named 'vllm.model_executor.guided_decoding'``