### PR TITLE
Fix vllm rocm 216 build

### DIFF
--- a/.tekton/vllm-rocm-216-pull-request.yaml
+++ b/.tekton/vllm-rocm-216-pull-request.yaml
@@ -52,6 +52,16 @@ spec:
   - name: rhoai-version
     value: "2.16.4"
   taskRunSpecs:
+  - pipelineTaskName: build-images
+    computeResources:
+      requests:
+        cpu: '12'
+        memory: 32Gi
+        ephemeral-storage: 130Gi
+      limits:
+        cpu: '16'
+        memory: 64Gi
+        ephemeral-storage: 150Gi
   - pipelineTaskName: ecosystem-cert-preflight-checks
     computeResources:
       requests:

--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -154,7 +154,10 @@ RUN --mount=type=cache,target=/root/.cache/ccache \
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install -v -U \
         ninja setuptools-scm>=8 "cmake>=3.26" packaging && \
-    env CFLAGS="-march=haswell" \
+    # Set CMAKE_POLICY_VERSION_MINIMUM to work around ROCm 6.2.4 hiprtc-config.cmake
+    # requiring VERSION <3.5, which is unsupported by CMake >=3.27
+    env CMAKE_POLICY_VERSION_MINIMUM=3.5 \
+        CFLAGS="-march=haswell" \
         CXXFLAGS="$CFLAGS $CXXFLAGS" \
         CMAKE_BUILD_TYPE=Release \
     python3 setup.py bdist_wheel --dist-dir=dist

--- a/Dockerfile.rocm.ubi
+++ b/Dockerfile.rocm.ubi
@@ -46,10 +46,10 @@ gpgkey=https://repo.radeon.com/rocm/rocm.gpg.key" > /etc/yum.repos.d/amdgpu.repo
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
-    uv pip install --pre \
-        --index-url "https://download.pytorch.org/whl/nightly/rocm${ROCM_VERSION}" \
-        torch==2.6.0.dev20241209+rocm${ROCM_VERSION} \
-        torchvision==0.20.0.dev20241209+rocm${ROCM_VERSION} && \
+    uv pip install \
+        --index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}" \
+        torch==2.6.0+rocm${ROCM_VERSION} \
+        torchvision==0.21.0+rocm${ROCM_VERSION} && \
     # Install libdrm-amdgpu to avoid errors when retrieving device information (amdgpu.ids: No such file or directory)
     microdnf install -y libdrm-amdgpu && \
     microdnf clean all
@@ -204,10 +204,9 @@ RUN --mount=type=bind,from=build_amdsmi,src=/install,target=/install/amdsmi/ \
     --mount=type=bind,from=build_vllm,src=/workspace/dist,target=/install/vllm/ \
     --mount=type=cache,target=/root/.cache/pip \
     --mount=type=cache,target=/root/.cache/uv \
-    export version="$(awk -F. '{print $1"."$2}' <<< $ROCM_VERSION)" && \
     uv pip install \
         --index-strategy=unsafe-best-match \
-        --extra-index-url "https://download.pytorch.org/whl/nightly/rocm${version}" \
+        --extra-index-url "https://download.pytorch.org/whl/rocm${ROCM_VERSION}" \
         /install/amdsmi/*.whl\
         /install/flashattention/*.whl\
         /install/vllm/*.whl \


### PR DESCRIPTION
This PR includes the changes present in https://github.com/red-hat-data-services/vllm/pull/21, which resolve a pytorch version install issue, as well as an additional commit that resolves an issue caused by conflicting cmake versions between the version installed in the Dockerfile and the minimum cmake version required by the ROCm runtime compiler `hiprtc` utilized by pytorch.

`hiprtc` requires a minimum cmake version `<3.5`. The Dockerfile installs cmake version `>=2.36`, i.e. the latest version which is `4.2.3`. CMake `>4.0` fully dropped support for policies defined using version `<3.5`, resulting in the build error:
```
  CMake Error at /opt/rocm/lib/cmake/hiprtc/hiprtc-config.cmake:21 (cmake_minimum_required):
    Compatibility with CMake < 3.5 has been removed from CMake.
  
    Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
    to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.
  
    Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```

The solution introduced in this PR tries to address the issue in a way that will result in the least amount of change in the build. CMake versions `>=4.0` support the use of a `CMAKE_POLICY_VERSION_MINIMUM` env variable, whereas CMake versions `<4.0` do not. This means if CMake versions `>=2.36` and `<4.0` are used for the build nothing will change (the env variable is ignored). If CMake version `>=4.0` is used, only dependencies with required version `<3.5` will be effected and will now use version `3.5`.